### PR TITLE
Set1 player controls engine tweaks

### DIFF
--- a/Assets/data/Scripts/Player/PlayerController.cs
+++ b/Assets/data/Scripts/Player/PlayerController.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 public class PlayerController : MonoBehaviour
 {
     [SerializeField] private controlScheme controller = controlScheme.Keyboard;
-    [SerializeField] private Camera camera;
+    [SerializeField] private Camera playerCamera;
     private Rigidbody2D rb2d;   
     private Engine engine;
     private HealthManager healthManager;
@@ -81,7 +81,7 @@ public class PlayerController : MonoBehaviour
     Vector2 getMouseAbsolute()
     {
         Vector3 mouseRelative = Input.mousePosition;
-        mouseRelative.z = camera.nearClipPlane;
-        return camera.ScreenToWorldPoint(mouseRelative);
+        mouseRelative.z = playerCamera.nearClipPlane;
+        return playerCamera.ScreenToWorldPoint(mouseRelative);
     }
 }

--- a/Assets/data/Scripts/Player/PlayerController.cs
+++ b/Assets/data/Scripts/Player/PlayerController.cs
@@ -1,15 +1,31 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.InteropServices.WindowsRuntime;
 using UnityEngine;
 
 public class PlayerController : MonoBehaviour
 {
+    [SerializeField] private controlScheme controller = controlScheme.Keyboard;
+    [SerializeField] private Camera camera;
+    private Rigidbody2D rb2d;   
     private Engine engine;
     private HealthManager healthManager;
     private Turret[] turrets;   
+
+    private float rotationInput = 0;
+    private Vector2 impulseVector = Vector2.zero;
+
+    private enum controlScheme
+    {
+        Mouse,
+        Keyboard
+    };
+
     // Start is called before the first frame update
     void Start()
     {
+        rb2d = gameObject.GetComponent<Rigidbody2D>();
         engine = gameObject.GetComponent<Engine>();
         healthManager = gameObject.GetComponent<HealthManager>();
         turrets = gameObject.GetComponentsInChildren<Turret>();
@@ -18,14 +34,54 @@ public class PlayerController : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        engine.rotation_input = Input.GetAxisRaw("Horizontal")* engine.MaxAngAcc;
-        engine.impulse_vector = transform.up*Input.GetAxisRaw("Vertical")*engine.MaxAcc;
-        if (Input.GetKey(KeyCode.Q))
+        rotationInput = 0;
+        impulseVector = Vector2.zero;
+
+        switch (controller)
         {
-            foreach(Turret turret in turrets)
-            {
-                turret.shoot();
-            }
+            case controlScheme.Keyboard:
+                if (Input.GetKey(KeyCode.LeftShift))
+                    impulseVector = transform.up*engine.MaxAcc;
+                if (Input.GetKey(KeyCode.RightArrow))
+                    rotationInput += engine.MaxAngAcc;
+                if (Input.GetKey(KeyCode.LeftArrow))
+                    rotationInput -= engine.MaxAngAcc;
+                if (Input.GetKey(KeyCode.Z))
+                    foreach(Turret turret in turrets)
+                        turret.shoot();
+                break;
+            case controlScheme.Mouse:
+                if (Input.GetKey(KeyCode.Mouse0))
+                    impulseVector = transform.up*engine.MaxAcc;
+                if (Input.GetKey(KeyCode.Mouse1))
+                    foreach(Turret turret in turrets)
+                        turret.shoot();
+                
+                Vector2 diff = getMouseAbsolute() - rb2d.position;
+
+                float delta = 90 - Mathf.Rad2Deg*Mathf.Atan2(diff.y,diff.x) + rb2d.rotation;
+                
+                if (Mathf.Abs(delta) > 180)
+                    delta-=Mathf.Sign(delta)*360;
+                
+                // Linearly ramp to maximum angular velocity depending on the delta of rotation
+                rotationInput = delta/180*engine.MaxAngAcc;
+
+                // Start slowing the angular velocity
+                if (Mathf.Abs(delta) < 90)
+                    rotationInput += rb2d.angularVelocity;
+                break;
+            default:
+                break;
         }
+
+        engine.rotation_input = rotationInput;
+        engine.impulse_vector = impulseVector;
+    }
+    Vector2 getMouseAbsolute()
+    {
+        Vector3 mouseRelative = Input.mousePosition;
+        mouseRelative.z = camera.nearClipPlane;
+        return camera.ScreenToWorldPoint(mouseRelative);
     }
 }

--- a/Assets/data/Scripts/lib/Engines/Engine.cs
+++ b/Assets/data/Scripts/lib/Engines/Engine.cs
@@ -6,18 +6,18 @@ using UnityEngine;
 public abstract class Engine : MonoBehaviour
 {
     private Rigidbody2D rb2D;
-    
+
     private Vector2 acceleration_real = Vector2.zero;
     private float angAcc_real = 0f;
 
-    private float maxAcc = 20f;
-    private float maxVel = 40f;
-    private float drag = 0.8f;
+    [SerializeField] private float maxAcc = 20f;
+    [SerializeField] private float maxVel = 40f;
+    [SerializeField] private float drag = 0.8f;
 
 
-    private float maxAngAcc = 720f;
-    private float maxAngVel = 270f;
-    private float angDrag = 3;
+    [SerializeField] private float maxAngAcc = 720f;
+    [SerializeField] private float maxAngVel = 270f;
+    [SerializeField] private float angDrag = 3;
 
     public float rotation_input;
 


### PR DESCRIPTION
Replaced contents of PlayerController with something a little more robust and readable. 
Implemented keyboard only controls and mouse only controls.
Made certain private member variables in Engine serialized so we can set them in unity.